### PR TITLE
Fix some examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ modules:
 Example with curl would query host1 with the password module and host2 with the default module.
 
 ```
-curl http://localhost:9312/ssh?target=host1.example.com:22&module=password
+curl "http://localhost:9312/ssh?target=host1.example.com:22&module=password"
 curl http://localhost:9312/ssh?target=host2.example.com:22
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ modules:
     command_expect: "load average"
     timeout: 5
   password:
-    id: prometheus
+    user: prometheus
     password: secret
   verify:
     user: prometheus
@@ -53,8 +53,8 @@ modules:
 Example with curl would query host1 with the password module and host2 with the default module.
 
 ```
-curl http://localhost:9310/ssh?target=host1.example.com&module=password
-curl http://localhost:9310/ssh?target=host2.example.com
+curl http://localhost:9312/ssh?target=host1.example.com:22&module=password
+curl http://localhost:9312/ssh?target=host2.example.com:22
 ```
 
 Configuration options for each module:


### PR DESCRIPTION
- `level=error ts=2021-09-30T11:49:15.705Z caller=ssh_exporter.go:95 msg="Error loading config" err="Error parsing config file ssh_exporter.yaml: yaml: unmarshal errors:\n  line 10: field id not found in type config.Module"`
- `level=info ts=2021-09-30T11:49:48.888Z caller=ssh_exporter.go:90 msg="Starting Server" address=:9312`
- `level=error ts=2021-09-30T11:51:07.616Z caller=collector.go:128 target=host1.example.com msg="Failed to establish SSH connection" err="dial tcp: address host1.example.com: missing port in address"`